### PR TITLE
Add agent edit and apply commands

### DIFF
--- a/frontend/cli/cmd/agent.go
+++ b/frontend/cli/cmd/agent.go
@@ -23,6 +23,8 @@ func NewAgentCmd() *cobra.Command {
 	cmd.AddCommand(NewAgentGetCmd())
 	cmd.AddCommand(NewAgentListCmd())
 	cmd.AddCommand(NewAgentDeleteCmd())
+	cmd.AddCommand(NewAgentEditCmd())
+	cmd.AddCommand(NewAgentApplyCmd())
 
 	return cmd
 }
@@ -36,16 +38,21 @@ type AgentDisplay struct {
 	CreatedAt    string `json:"created_at" yaml:"created_at" detail:"full"`
 }
 
-func ConvertAgentToDisplay(agent *v1.Agent, model *v1.Model) *AgentDisplay {
+func ConvertAgentToDisplay(agent *v1.Agent, modelName string) *AgentDisplay {
 	if agent == nil || agent.Metadata == nil || agent.Spec == nil {
 		return nil
 	}
+
+	if modelName == "" {
+		modelName = "none"
+	}
+
 	return &AgentDisplay{
 		ID:           agent.Id,
 		Name:         agent.Metadata.Name,
 		Description:  agent.Metadata.Description,
 		Instructions: agent.Spec.Instructions,
-		Model:        model.Name,
+		Model:        modelName,
 	}
 }
 

--- a/frontend/cli/cmd/agent_apply.go
+++ b/frontend/cli/cmd/agent_apply.go
@@ -1,0 +1,192 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"connectrpc.com/connect"
+	api "github.com/furisto/construct/api/go/client"
+	v1 "github.com/furisto/construct/api/go/v1"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+type agentApplyOptions struct {
+	Filename string
+}
+
+// AgentSpec represents the YAML structure for agent apply
+type AgentSpec struct {
+	ID           string `yaml:"id,omitempty"`
+	Name         string `yaml:"name"`
+	Description  string `yaml:"description,omitempty"`
+	Instructions string `yaml:"instructions"`
+	Model        string `yaml:"model"`
+}
+
+func NewAgentApplyCmd() *cobra.Command {
+	var options agentApplyOptions
+
+	cmd := &cobra.Command{
+		Use:   "apply -f <file.yaml>",
+		Short: "Apply agent configuration from a YAML file",
+		Long: `Apply agent configuration from a YAML file.
+
+This command reads an agent specification from a YAML file and either creates 
+a new agent or updates an existing one based on whether an ID is specified 
+in the file.
+
+This is the declarative, automation-friendly way to manage agents, perfect 
+for CI/CD pipelines and scripted workflows.`,
+		Example: `  # Apply agent configuration from file
+  construct agent apply -f coder.yaml
+
+  # Get current config, modify, and apply
+  construct agent get "coder" -o yaml > coder.yaml
+  # ... edit coder.yaml ...
+  construct agent apply -f coder.yaml`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if options.Filename == "" {
+				return fmt.Errorf("filename is required. Use -f to specify the YAML file")
+			}
+
+			client := getAPIClient(cmd.Context())
+
+			// Read and parse the YAML file
+			spec, err := parseAgentSpecFile(options.Filename)
+			if err != nil {
+				return fmt.Errorf("failed to parse agent spec file: %w", err)
+			}
+
+			// Determine if this is a create or update operation
+			if spec.ID == "" {
+				// Create new agent
+				return createAgentFromSpec(cmd.Context(), client, spec, cmd)
+			} else {
+				// Update existing agent
+				return updateAgentFromSpec(cmd.Context(), client, spec, cmd)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.Filename, "filename", "f", "", "YAML file containing agent specification")
+	cmd.MarkFlagRequired("filename")
+
+	return cmd
+}
+
+func parseAgentSpecFile(filename string) (*AgentSpec, error) {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var spec AgentSpec
+	if err := yaml.Unmarshal(content, &spec); err != nil {
+		return nil, fmt.Errorf("invalid YAML format: %w", err)
+	}
+
+	// Validate required fields
+	if spec.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	if spec.Instructions == "" {
+		return nil, fmt.Errorf("instructions are required")
+	}
+	if spec.Model == "" {
+		return nil, fmt.Errorf("model is required")
+	}
+
+	return &spec, nil
+}
+
+func createAgentFromSpec(ctx context.Context, client *api.Client, spec *AgentSpec, cmd *cobra.Command) error {
+	// Resolve model ID if name was provided
+	modelID := spec.Model
+	if _, err := uuid.Parse(modelID); err != nil {
+		// It's a model name, resolve to ID
+		resolvedID, err := getModelID(ctx, client, modelID)
+		if err != nil {
+			return fmt.Errorf("failed to resolve model %s: %w", modelID, err)
+		}
+		modelID = resolvedID
+	}
+
+	// Create the agent
+	agentResp, err := client.Agent().CreateAgent(ctx, &connect.Request[v1.CreateAgentRequest]{
+		Msg: &v1.CreateAgentRequest{
+			Name:         spec.Name,
+			Description:  spec.Description,
+			Instructions: spec.Instructions,
+			ModelId:      modelID,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create agent: %w", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "agent.construct.ai/%s created\n", spec.Name)
+	fmt.Fprintf(cmd.OutOrStdout(), "ID: %s\n", agentResp.Msg.Agent.Id)
+	return nil
+}
+
+func updateAgentFromSpec(ctx context.Context, client *api.Client, spec *AgentSpec, cmd *cobra.Command) error {
+	// Validate that the ID is a valid UUID
+	agentID := spec.ID
+	if _, err := uuid.Parse(agentID); err != nil {
+		return fmt.Errorf("invalid agent ID format: %s", agentID)
+	}
+
+	// Fetch current agent to see what changed
+	currentAgentResp, err := client.Agent().GetAgent(ctx, &connect.Request[v1.GetAgentRequest]{
+		Msg: &v1.GetAgentRequest{Id: agentID},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get existing agent: %w", err)
+	}
+
+	currentAgent := currentAgentResp.Msg.Agent
+
+	// Resolve model ID if name was provided
+	modelID := spec.Model
+	if _, err := uuid.Parse(modelID); err != nil {
+		// It's a model name, resolve to ID
+		resolvedID, err := getModelID(ctx, client, modelID)
+		if err != nil {
+			return fmt.Errorf("failed to resolve model %s: %w", modelID, err)
+		}
+		modelID = resolvedID
+	}
+
+	// Build update request with only changed fields
+	updateReq := &v1.UpdateAgentRequest{
+		Id: agentID,
+	}
+
+	// Check what fields have changed and set them in the update request
+	if spec.Name != currentAgent.Metadata.Name {
+		updateReq.Name = &spec.Name
+	}
+	if spec.Description != currentAgent.Metadata.Description {
+		updateReq.Description = &spec.Description
+	}
+	if spec.Instructions != currentAgent.Spec.Instructions {
+		updateReq.Instructions = &spec.Instructions
+	}
+	if modelID != currentAgent.Spec.ModelId {
+		updateReq.ModelId = &modelID
+	}
+
+	// Apply the update
+	_, err = client.Agent().UpdateAgent(ctx, &connect.Request[v1.UpdateAgentRequest]{
+		Msg: updateReq,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update agent: %w", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "agent.construct.ai/%s configured\n", spec.Name)
+	return nil
+}

--- a/frontend/cli/cmd/agent_edit.go
+++ b/frontend/cli/cmd/agent_edit.go
@@ -1,0 +1,265 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+
+	"connectrpc.com/connect"
+	api "github.com/furisto/construct/api/go/client"
+	v1 "github.com/furisto/construct/api/go/v1"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// AgentEditSpec represents the editable structure of an agent
+type AgentEditSpec struct {
+	// Commented header to guide users
+	ID           string `yaml:"id" comment:"# Agent ID (read-only)"`
+	Name         string `yaml:"name" comment:"# Agent name"`
+	Description  string `yaml:"description,omitempty" comment:"# Agent description (optional)"`
+	Instructions string `yaml:"instructions" comment:"# System instructions/prompt"`
+	Model        string `yaml:"model" comment:"# Model name or ID"`
+}
+
+func NewAgentEditCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "edit <id-or-name>",
+		Short: "Edit an agent configuration interactively using your default editor",
+		Long: `Edit an agent configuration using your default editor ($EDITOR).
+
+This command fetches the current agent configuration, opens it as a YAML file 
+in your terminal editor, and applies any changes you make upon saving and 
+closing the editor.
+
+Similar to 'kubectl edit', this provides a powerful way to make multiple 
+changes to an agent in a single operation.`,
+		Args: cobra.ExactArgs(1),
+		Example: `  # Edit agent by name
+  construct agent edit "coder"
+
+  # Edit agent by ID  
+  construct agent edit 01974c1d-0be8-70e1-88b4-ad9462fff25e
+
+  # Set custom editor
+  EDITOR=nano construct agent edit "coder"`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := getAPIClient(cmd.Context())
+			idOrName := args[0]
+
+			// Resolve agent ID
+			agentID, err := getAgentID(cmd.Context(), client, idOrName)
+			if err != nil {
+				return fmt.Errorf("failed to resolve agent %s: %w", idOrName, err)
+			}
+
+			// Fetch current agent configuration
+			agentResp, err := client.Agent().GetAgent(cmd.Context(), &connect.Request[v1.GetAgentRequest]{
+				Msg: &v1.GetAgentRequest{Id: agentID},
+			})
+			if err != nil {
+				return fmt.Errorf("failed to get agent %s: %w", idOrName, err)
+			}
+
+			// Fetch model information for display
+			modelResp, err := client.Model().GetModel(cmd.Context(), &connect.Request[v1.GetModelRequest]{
+				Msg: &v1.GetModelRequest{
+					Id: agentResp.Msg.Agent.Spec.ModelId,
+				},
+			})
+			if err != nil {
+				return fmt.Errorf("failed to get model %s: %w", agentResp.Msg.Agent.Spec.ModelId, err)
+			}
+
+			// Convert to editable spec
+			editSpec := &AgentEditSpec{
+				ID:           agentResp.Msg.Agent.Id,
+				Name:         agentResp.Msg.Agent.Metadata.Name,
+				Description:  agentResp.Msg.Agent.Metadata.Description,
+				Instructions: agentResp.Msg.Agent.Spec.Instructions,
+				Model:        modelResp.Msg.Model.Name,
+			}
+
+			// Save original spec for comparison
+			originalSpec := *editSpec
+
+			// Create temporary file with YAML content
+			tempFile, err := createTempYAMLFile(editSpec)
+			if err != nil {
+				return fmt.Errorf("failed to create temporary file: %w", err)
+			}
+			defer os.Remove(tempFile)
+
+			// Open editor
+			if err := openEditor(tempFile); err != nil {
+				return fmt.Errorf("failed to open editor: %w", err)
+			}
+
+			// Parse edited content
+			editedSpec, err := parseYAMLFile(tempFile)
+			if err != nil {
+				return fmt.Errorf("failed to parse edited content: %w", err)
+			}
+
+			// Check if any changes were made
+			if reflect.DeepEqual(originalSpec, *editedSpec) {
+				fmt.Fprintln(cmd.OutOrStdout(), "No changes made.")
+				return nil
+			}
+
+			// Validate that ID hasn't changed
+			if editedSpec.ID != originalSpec.ID {
+				return fmt.Errorf("agent ID cannot be modified")
+			}
+
+			// Apply the changes
+			if err := applyAgentChanges(cmd.Context(), client, agentResp.Msg.Agent, editedSpec); err != nil {
+				return fmt.Errorf("failed to apply changes: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "agent.construct.ai/%s edited\n", editedSpec.Name)
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func createTempYAMLFile(spec *AgentEditSpec) (string, error) {
+	// Create temporary file
+	tempFile, err := os.CreateTemp("", "construct-agent-*.yaml")
+	if err != nil {
+		return "", err
+	}
+	defer tempFile.Close()
+
+	// Create YAML content with helpful comments
+	content := fmt.Sprintf(`# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+id: %s
+name: %s
+description: %s
+instructions: |
+%s
+model: %s
+`,
+		spec.ID,
+		spec.Name,
+		spec.Description,
+		indentString(spec.Instructions, "  "),
+		spec.Model,
+	)
+
+	if _, err := tempFile.WriteString(content); err != nil {
+		return "", err
+	}
+
+	return tempFile.Name(), nil
+}
+
+func openEditor(filename string) error {
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editors := []string{"code", "cursor", "vim", "nano", "emacs", "vi"}
+		for _, e := range editors {
+			if _, err := exec.LookPath(e); err == nil {
+				editor = e
+				break
+			}
+		}
+	}
+
+	if editor == "" {
+		return fmt.Errorf("no editor found. Please set the EDITOR environment variable")
+	}
+
+	cmd := exec.Command(editor, filename)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+func parseYAMLFile(filename string) (*AgentEditSpec, error) {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var spec AgentEditSpec
+	if err := yaml.Unmarshal(content, &spec); err != nil {
+		return nil, fmt.Errorf("invalid YAML format: %w", err)
+	}
+
+	// Validate required fields
+	if spec.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	if spec.Instructions == "" {
+		return nil, fmt.Errorf("instructions are required")
+	}
+	if spec.Model == "" {
+		return nil, fmt.Errorf("model is required")
+	}
+
+	return &spec, nil
+}
+
+func applyAgentChanges(ctx context.Context, client *api.Client, currentAgent *v1.Agent, editedSpec *AgentEditSpec) error {
+	// Resolve model ID if name was provided
+	modelID := editedSpec.Model
+	if _, err := uuid.Parse(modelID); err != nil {
+		// It's a model name, resolve to ID
+		resolvedID, err := getModelID(ctx, client, modelID)
+		if err != nil {
+			return fmt.Errorf("failed to resolve model %s: %w", modelID, err)
+		}
+		modelID = resolvedID
+	}
+
+	// Build update request
+	updateReq := &v1.UpdateAgentRequest{
+		Id: currentAgent.Id,
+	}
+
+	// Check what fields have changed and set them in the update request
+	if editedSpec.Name != currentAgent.Metadata.Name {
+		updateReq.Name = &editedSpec.Name
+	}
+	if editedSpec.Description != currentAgent.Metadata.Description {
+		updateReq.Description = &editedSpec.Description
+	}
+	if editedSpec.Instructions != currentAgent.Spec.Instructions {
+		updateReq.Instructions = &editedSpec.Instructions
+	}
+	if modelID != currentAgent.Spec.ModelId {
+		updateReq.ModelId = &modelID
+	}
+
+	// Apply the update
+	_, err := client.Agent().UpdateAgent(ctx, &connect.Request[v1.UpdateAgentRequest]{
+		Msg: updateReq,
+	})
+
+	return err
+}
+
+func indentString(s, indent string) string {
+	if s == "" {
+		return s
+	}
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = indent + line
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/frontend/cli/cmd/agent_get.go
+++ b/frontend/cli/cmd/agent_get.go
@@ -48,18 +48,22 @@ func NewAgentGetCmd() *cobra.Command {
 				return fmt.Errorf("failed to get agent %s: %w", idOrName, err)
 			}
 
-			modelResp, err := client.Model().GetModel(cmd.Context(), &connect.Request[v1.GetModelRequest]{
-				Msg: &v1.GetModelRequest{
-					Id: agentResp.Msg.Agent.Spec.ModelId,
-				},
-			})
+			var modelName string
+			if agentResp.Msg.Agent.Spec.ModelId != "" {
+				modelResp, err := client.Model().GetModel(cmd.Context(), &connect.Request[v1.GetModelRequest]{
+					Msg: &v1.GetModelRequest{
+						Id: agentResp.Msg.Agent.Spec.ModelId,
+					},
+				})
+	
+				if err != nil {
+					return fmt.Errorf("failed to get model %s: %w", agentResp.Msg.Agent.Spec.ModelId, err)
+				}
 
-			if err != nil {
-				return fmt.Errorf("failed to get model %s: %w", agentResp.Msg.Agent.Spec.ModelId, err)
+				modelName = modelResp.Msg.Model.Name
 			}
 
-			displayAgent := ConvertAgentToDisplay(agentResp.Msg.Agent, modelResp.Msg.Model)
-
+			displayAgent := ConvertAgentToDisplay(agentResp.Msg.Agent, modelName)
 			return getRenderer(cmd.Context()).Render(displayAgent, &options.RenderOptions)
 		},
 	}

--- a/frontend/cli/cmd/agent_list.go
+++ b/frontend/cli/cmd/agent_list.go
@@ -104,7 +104,7 @@ func NewAgentListCmd() *cobra.Command {
 					return fmt.Errorf("failed to get model %s: %w", agent.Spec.ModelId, err)
 				}
 
-				displayAgents[i] = ConvertAgentToDisplay(agent, model.Msg.Model)
+				displayAgents[i] = ConvertAgentToDisplay(agent, model.Msg.Model.Name)
 			}
 
 			// Handle columns filtering if specified


### PR DESCRIPTION
- Add `agent edit` command for interactive YAML-based agent configuration editing using $EDITOR
- Add `agent apply` command for declarative agent management from YAML files
- Improve model name resolution and error handling in agent get/list commands
- Support both create and update operations in apply command based on ID presence
- Follow kubectl-style workflow for better DevOps integration and automation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI command: agent apply — reads an agent spec from YAML to create or update agents with validation and clear feedback.
  * Added CLI command: agent edit — opens your editor for interactive YAML-based editing with change detection and selective updates.

* **Improvements**
  * Agent display now shows the model name directly and defaults to “none” when no model is set.
  * More robust agent get/list behavior by only fetching model details when available, reducing unnecessary errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->