### PR TITLE
Add task resumption with pagination and UUID prefix filtering

### DIFF
--- a/backend/api/task.go
+++ b/backend/api/task.go
@@ -125,6 +125,10 @@ func (h *TaskHandler) ListTasks(ctx context.Context, req *connect.Request[v1.Lis
 		}
 	}
 
+	if req.Msg.PageSize != nil {
+		query = query.Limit(int(*req.Msg.PageSize))
+	}
+
 	tasks, err := query.WithAgent().All(ctx)
 	if err != nil {
 		return nil, apiError(err)

--- a/backend/memory/extension/extension.go
+++ b/backend/memory/extension/extension.go
@@ -1,0 +1,33 @@
+package extension
+
+import (
+	"entgo.io/ent/dialect"
+	"entgo.io/ent/dialect/sql"
+	"github.com/furisto/construct/backend/memory/predicate"
+)
+
+func UUIDHasPrefix(field string, prefix string) predicate.Task {
+	return func(s *sql.Selector) {
+		d := s.Dialect()
+
+		switch d {
+		case dialect.SQLite:
+			// UUIDs are stored as formatted strings in SQLite
+			s.Where(sql.P(func(b *sql.Builder) {
+				b.Ident(field).WriteString(" LIKE ").Arg(prefix + "%")
+			}))
+
+		case dialect.Postgres:
+			// PostgreSQL can cast UUID to text
+			s.Where(sql.P(func(b *sql.Builder) {
+				b.Ident(field).WriteString("::text LIKE ").Arg(prefix + "%")
+			}))
+
+		default:
+			s.Where(sql.P(func(b *sql.Builder) {
+				b.WriteString("CAST(").Ident(field).WriteString(" AS CHAR) LIKE ").
+					Arg(prefix + "%")
+			}))
+		}
+	}
+}

--- a/frontend/cli/cmd/new.go
+++ b/frontend/cli/cmd/new.go
@@ -70,7 +70,8 @@ func handleNewCommand(ctx context.Context, apiClient *api.Client, options *newOp
 	agent := agentResp.Msg.Agent
 	resp, err := apiClient.Task().CreateTask(ctx, &connect.Request[v1.CreateTaskRequest]{
 		Msg: &v1.CreateTaskRequest{
-			AgentId: agent.Metadata.Id,
+			AgentId:     agent.Metadata.Id,
+			Description: "Build a Go-based coding agent with Anthropic and OpenAI API integration",
 		},
 	})
 

--- a/frontend/cli/cmd/resume.go
+++ b/frontend/cli/cmd/resume.go
@@ -1,12 +1,30 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"os"
 
+	"connectrpc.com/connect"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+
+	api "github.com/furisto/construct/api/go/client"
+	v1 "github.com/furisto/construct/api/go/v1"
+	"github.com/furisto/construct/frontend/cli/pkg/fail"
+	"github.com/furisto/construct/frontend/cli/pkg/terminal"
 )
 
+type resumeOptions struct {
+	last  bool
+	all   bool
+	limit int
+}
+
 func NewResumeCmd() *cobra.Command {
+	options := &resumeOptions{}
+
 	cmd := &cobra.Command{
 		Use:   "resume [task-id] [flags]",
 		Short: "Resume an existing conversation",
@@ -25,14 +43,213 @@ Examples:
   construct resume --last
 
   # Resume specific task by full ID
-  construct resume 01974c1d-0be8-70e1-88b4-ad9462fff25e`,
+  construct resume 01974c1d-0be8-70e1-88b4-ad9462fff25e
+
+  # Show more tasks, including non-interactive ones, in the picker
+  construct resume --all --limit 20`,
 		GroupID: "core",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("Resuming task", args[0])
+		RunE: func(cmd *cobra.Command, args []string) error {
+			apiClient := getAPIClient(cmd.Context())
+
+			return fail.HandleError(handleResumeCommand(cmd.Context(), apiClient, options, args))
 		},
 	}
 
-	cmd.Flags().Bool("last", false, "Resume the most recent task immediately")
+	cmd.Flags().BoolVar(&options.last, "last", false, "Resume the most recent task immediately")
+	cmd.Flags().BoolVar(&options.all, "all", false, "Show all tasks in the picker, including non-interactive ones")
+	cmd.Flags().IntVar(&options.limit, "limit", 10, "Maximum number of tasks to show in the picker")
 
 	return cmd
 }
+
+func handleResumeCommand(ctx context.Context, apiClient *api.Client, options *resumeOptions, args []string) error {
+	if len(args) > 0 {
+		taskID := args[0]
+		return resumeTaskByID(ctx, apiClient, taskID)
+	}
+
+	if options.last {
+		return resumeMostRecentTask(ctx, apiClient)
+	}
+
+	return showTaskPicker(ctx, apiClient, options)
+}
+
+func resumeTaskByID(ctx context.Context, apiClient *api.Client, taskID string) error {
+	task, err := resolveTaskID(ctx, apiClient, taskID)
+	if err != nil {
+		return fmt.Errorf("failed to resolve task ID %s: %w", taskID, err)
+	}
+
+	return resumeTask(ctx, apiClient, task)
+}
+
+func resumeMostRecentTask(ctx context.Context, apiClient *api.Client) error {
+	resp, err := apiClient.Task().ListTasks(ctx, &connect.Request[v1.ListTasksRequest]{
+		Msg: &v1.ListTasksRequest{
+			Filter:    &v1.ListTasksRequest_Filter{},
+			SortField: api.Ptr(v1.SortField_SORT_FIELD_UPDATED_AT),
+			SortOrder: api.Ptr(v1.SortOrder_SORT_ORDER_DESC),
+			PageSize:  api.Ptr(int32(1)),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list tasks: %w", err)
+	}
+
+	if len(resp.Msg.Tasks) == 0 {
+		return fmt.Errorf("no tasks created yet")
+	}
+
+	mostRecentTask := resp.Msg.Tasks[0]
+	return resumeTaskByID(ctx, apiClient, mostRecentTask.Metadata.Id)
+}
+
+func resumeTask(ctx context.Context, apiClient *api.Client, task *v1.Task) error {
+	agentResp, err := apiClient.Agent().GetAgent(ctx, &connect.Request[v1.GetAgentRequest]{
+		Msg: &v1.GetAgentRequest{Id: PtrToString(task.Spec.AgentId)},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get agent: %w", err)
+	}
+
+	return startInteractiveSession(ctx, apiClient, task, agentResp.Msg.Agent)
+}
+
+func showTaskPicker(ctx context.Context, apiClient *api.Client, options *resumeOptions) error {
+	resp, err := apiClient.Task().ListTasks(ctx, &connect.Request[v1.ListTasksRequest]{
+		Msg: &v1.ListTasksRequest{
+			PageSize:  api.Ptr(int32(options.limit)),
+			SortField: api.Ptr(v1.SortField_SORT_FIELD_CREATED_AT),
+			SortOrder: api.Ptr(v1.SortOrder_SORT_ORDER_DESC),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list tasks: %w", err)
+	}
+
+	if len(resp.Msg.Tasks) == 0 {
+		return fmt.Errorf("no tasks found")
+	}
+
+	headers := []string{"ID", "Agent ID", "Workspace"}
+	var tableRows []terminal.TableRow
+
+	for _, task := range resp.Msg.Tasks {
+		agentID := PtrToString(task.Spec.AgentId)
+		workspace := task.Spec.Workspace
+		if workspace == "" {
+			workspace = "."
+		}
+
+		tableRows = append(tableRows, terminal.TableRow{
+			Data: []string{task.Metadata.Id, agentID, workspace},
+			Task: task,
+		})
+	}
+
+	table := terminal.NewSelectableTable("Select a task to resume", headers, tableRows)
+	program := tea.NewProgram(table, tea.WithAltScreen())
+
+	finalModel, err := program.Run()
+	if err != nil {
+		return fmt.Errorf("error running task picker: %w", err)
+	}
+
+	tableModel := finalModel.(*terminal.SelectableTable)
+	if tableModel.IsCancelled() {
+		return nil
+	}
+
+	selectedTask := tableModel.GetSelectedTask()
+	if selectedTask == nil {
+		return fmt.Errorf("no task selected")
+	}
+
+	return resumeTask(ctx, apiClient, selectedTask)
+}
+
+func resolveTaskID(ctx context.Context, apiClient *api.Client, taskID string) (*v1.Task, error) {
+	if len(taskID) < 8 {
+		return nil, fmt.Errorf("task ID must be at least 4 characters long")
+	}
+
+	parsedTaskID, err := uuid.Parse(taskID)
+	if err == nil {
+		taskResp, err := apiClient.Task().GetTask(ctx, &connect.Request[v1.GetTaskRequest]{
+			Msg: &v1.GetTaskRequest{Id: parsedTaskID.String()},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get task %s: %w", taskID, err)
+		}
+
+		return taskResp.Msg.Task, nil
+	}
+
+	// Otherwise, try to find a task with a matching prefix
+	resp, err := apiClient.Task().ListTasks(ctx, &connect.Request[v1.ListTasksRequest]{
+		Msg: &v1.ListTasksRequest{
+			Filter: &v1.ListTasksRequest_Filter{
+				TaskIdPrefix: &taskID,
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tasks: %w", err)
+	}
+
+	if len(resp.Msg.Tasks) == 0 {
+		return nil, fmt.Errorf("no task found matching %s", taskID)
+	}
+
+	if len(resp.Msg.Tasks) > 1 {
+		return nil, fmt.Errorf("multiple tasks found matching %s", taskID)
+	}
+
+	return resp.Msg.Tasks[0], nil
+}
+
+func startInteractiveSession(ctx context.Context, apiClient *api.Client, task *v1.Task, agent *v1.Agent) error {
+	program := tea.NewProgram(
+		terminal.NewModel(ctx, apiClient, task, agent),
+		tea.WithAltScreen(),
+	)
+
+	fmt.Printf("Subscribed to task %s\n", task.Metadata.Id)
+	go func() {
+		watch, err := apiClient.Task().Subscribe(ctx, &connect.Request[v1.SubscribeRequest]{
+			Msg: &v1.SubscribeRequest{
+				TaskId: task.Metadata.Id,
+			},
+		})
+		if err != nil {
+			fmt.Printf("error subscribing to task: %v\n", err)
+			return
+		}
+
+		defer watch.Close()
+
+		for watch.Receive() {
+			msg := watch.Msg()
+			program.Send(msg.Message)
+		}
+
+		if err := watch.Err(); err != nil {
+			fmt.Printf("error watching task: %v\n", err)
+		}
+	}()
+
+	tempFile, err := os.CreateTemp("", "construct-resume-*")
+	if err != nil {
+		return err
+	}
+
+	tea.LogToFile(tempFile.Name(), "debug")
+
+	if _, err := program.Run(); err != nil {
+		return fmt.Errorf("error running program: %w", err)
+	}
+
+	return nil
+}
+

--- a/frontend/cli/pkg/terminal/table.go
+++ b/frontend/cli/pkg/terminal/table.go
@@ -1,0 +1,201 @@
+package terminal
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	v1 "github.com/furisto/construct/api/go/v1"
+)
+
+type SelectableTable struct {
+	title       string
+	headers     []string
+	rows        []TableRow
+	selected    int
+	width       int
+	height      int
+	cancelled   bool
+	headerStyle lipgloss.Style
+	rowStyle    lipgloss.Style
+	selectedStyle lipgloss.Style
+}
+
+type TableRow struct {
+	Data []string
+	Task *v1.Task
+}
+
+func NewSelectableTable(title string, headers []string, rows []TableRow) *SelectableTable {
+	return &SelectableTable{
+		title:       title,
+		headers:     headers,
+		rows:        rows,
+		selected:    0,
+		width:       80,
+		height:      20,
+		cancelled:   false,
+		headerStyle: lipgloss.NewStyle().
+			Foreground(lipgloss.Color("39")).
+			Bold(true).
+			Padding(0, 1),
+		rowStyle: lipgloss.NewStyle().
+			Foreground(lipgloss.Color("252")).
+			Padding(0, 1),
+		selectedStyle: lipgloss.NewStyle().
+			Foreground(lipgloss.Color("39")).
+			Background(lipgloss.Color("236")).
+			Bold(true).
+			Padding(0, 1),
+	}
+}
+
+func (t *SelectableTable) Init() tea.Cmd {
+	return nil
+}
+
+func (t *SelectableTable) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		t.width = msg.Width
+		t.height = msg.Height
+		return t, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q", "esc":
+			t.cancelled = true
+			return t, tea.Quit
+
+		case "enter":
+			return t, tea.Quit
+
+		case "up", "k":
+			if t.selected > 0 {
+				t.selected--
+			}
+
+		case "down", "j":
+			if t.selected < len(t.rows)-1 {
+				t.selected++
+			}
+
+		case "home", "g":
+			t.selected = 0
+
+		case "end", "G":
+			t.selected = len(t.rows) - 1
+
+		case "pageup", "b":
+			t.selected = max(0, t.selected-10)
+
+		case "pagedown", "f":
+			t.selected = min(len(t.rows)-1, t.selected+10)
+		}
+	}
+
+	return t, nil
+}
+
+func (t *SelectableTable) View() string {
+	if len(t.rows) == 0 {
+		return lipgloss.Place(
+			t.width,
+			t.height,
+			lipgloss.Center,
+			lipgloss.Center,
+			"No tasks found",
+		)
+	}
+
+	var lines []string
+
+	lines = append(lines, t.headerStyle.Render(t.title))
+	lines = append(lines, "")
+
+	header := t.renderHeader()
+	lines = append(lines, header)
+	lines = append(lines, strings.Repeat("─", t.width-4))
+
+	for i, row := range t.rows {
+		rowStr := t.renderRow(i, row)
+		lines = append(lines, rowStr)
+	}
+
+	lines = append(lines, "")
+	lines = append(lines, "Press ↑/↓ or j/k to navigate, Enter to select, Esc to cancel")
+
+	return strings.Join(lines, "\n")
+}
+
+func (t *SelectableTable) renderHeader() string {
+	const idWidth = 36
+	const agentIdWidth = 36
+	const workspaceWidth = 50
+
+	header := fmt.Sprintf("%-*s  %-*s  %-*s",
+		idWidth, t.headers[0],
+		agentIdWidth, t.headers[1], 
+		workspaceWidth, t.headers[2])
+
+	return t.headerStyle.Render(header)
+}
+
+func (t *SelectableTable) renderRow(index int, row TableRow) string {
+	const idWidth = 36
+	const agentIdWidth = 36
+	const workspaceWidth = 50
+
+	taskID := row.Data[0]
+	if len(taskID) > idWidth {
+		taskID = taskID[:idWidth-3] + "..."
+	}
+
+	agentID := row.Data[1]
+	if len(agentID) > agentIdWidth {
+		agentID = agentID[:agentIdWidth-3] + "..."
+	}
+
+	workspace := row.Data[2]
+	if len(workspace) > workspaceWidth {
+		workspace = "..." + workspace[len(workspace)-(workspaceWidth-3):]
+	}
+
+	rowStr := fmt.Sprintf("%-*s  %-*s  %-*s",
+		idWidth, taskID,
+		agentIdWidth, agentID,
+		workspaceWidth, workspace)
+
+	style := t.rowStyle
+	if index == t.selected {
+		style = t.selectedStyle
+	}
+
+	return style.Render(rowStr)
+}
+
+func (t *SelectableTable) GetSelectedTask() *v1.Task {
+	if t.cancelled || t.selected >= len(t.rows) {
+		return nil
+	}
+	return t.rows[t.selected].Task
+}
+
+func (t *SelectableTable) IsCancelled() bool {
+	return t.cancelled
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
- Add pagination support to ListTasks API with configurable page size
- Implement UUIDHasPrefix extension for cross-database UUID prefix queries
- Add comprehensive resume command with interactive task picker
- Support task selection by ID prefix, full ID, or --last flag
- Include selectable table component with keyboard navigation
- Set default task description for new tasks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - CLI: Added interactive “resume task” workflow with an on-screen task picker.
  - CLI: New flags for resuming tasks: --last, --all, --limit.
  - CLI: Resume tasks by full ID or matching prefix.
  - CLI: New default description included when creating a task.

- Improvements
  - Task list pagination supported when a page size is provided, enabling faster, more manageable listings.
  - Enhanced terminal UI for browsing and selecting tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->